### PR TITLE
Fix #29

### DIFF
--- a/src/main/java/dev/rvbsm/fsit/mixin/AreaEffectCloudEntityMixin.java
+++ b/src/main/java/dev/rvbsm/fsit/mixin/AreaEffectCloudEntityMixin.java
@@ -19,6 +19,7 @@ public abstract class AreaEffectCloudEntityMixin extends Entity {
 
 	@Inject(method = "tick", at = @At("TAIL"))
 	private void tick$cleanSit(CallbackInfo ci) {
-		if (this.age > 20 && !this.hasPassengers() && this.getCustomName() == SeatEntity.CUSTOM_NAME) this.discard();
+		if (this.age > 20 && !this.hasPassengers() && this.getCustomName() != null && this.getCustomName().equals(SeatEntity.CUSTOM_NAME))
+			this.discard();
 	}
 }


### PR DESCRIPTION
replace `==` with `.equals` to check for equality by content, not by reference. This then properly discards the entity, when rejoining the server.